### PR TITLE
Added is_check to waitForTurn endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Or if game could not be started because server is full:
     "board_data": String[8][8],
     "move_data": JSON[],
     "won": Boolean,
-    "lost": Boolean,
+    "lost": Boolean
 }
 ```
 
@@ -133,6 +133,7 @@ Or if game could not be started because server is full:
     "move_data": JSON[],
     "won": Boolean,
     "lost": Boolean,
+    "is_check": Boolean
 }
 ```
 
@@ -146,7 +147,7 @@ Or if game could not be started because server is full:
     "board_data": String[8][8],
     "move_data": JSON[],
     "won": False,
-    "lost": True,
+    "lost": True
 }
 ```
 

--- a/server.py
+++ b/server.py
@@ -108,8 +108,8 @@ def wait_for_player():
 					"status_code": 200,
 					"board_data": server_to_client(board),
 					"move_data": board.getLegalMoves(player_num_to_color[player_number]),
-                                        "won": False,
-                                        "lost": False
+					"won": False,
+					"lost": False
 				}
 			)
 
@@ -135,7 +135,8 @@ def wait_for_turn():
 				"board_data": server_to_client(board),
 				"move_data": [],
 				"won": True,
-				"lost": False
+				"lost": False,
+				"is_check": board.isCheck(players[player_number].color)
 			}
 		)
 
@@ -157,6 +158,7 @@ def wait_for_turn():
 				"move_data": [],
 				"won": False,
 				"lost": True,
+				"is_check": board.isCheck(players[player_number].color)
 			}
 		)
 
@@ -167,7 +169,8 @@ def wait_for_turn():
 			"board_data": server_to_client(board),
 			"move_data": moves,
 			"won": False,
-			"lost": False
+			"lost": False,
+			"is_check": board.isCheck(players[player_number].color)
 		}
 	)
 


### PR DESCRIPTION
The player needs to know when they are in check, and adding this value to the `waitForTurn` endpoint will make it much easier for them to know.
This addresses #34 