### PR TITLE
Fix Pawn Promotion

### DIFF
--- a/Boardstuff.py
+++ b/Boardstuff.py
@@ -179,6 +179,16 @@ if __name__ == "__main__":
     # b.apply_move("white", [7, 4, 7, 6])
     # b.print_board_white()
 
+    """Promotion test"""
+    # b.move_piece_fast(0, 7, 5, 5)
+    # b.move_piece_fast(1, 7, 5, 6)
+    # b.move_piece_fast(6, 7, 1, 7)
+    # b.print_board_white()
+    # b.apply_move("white", [1, 7, 0, 6])
+    # b.pawn_promotion("Queen", [0, 6])
+    # b.print_board_white()
+    # print(b.get_legal_moves("white"))
+
 
 
     # print("Is the king in check?", b.isCheck("white"))

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Many endpoints are used by the client and server to communicate with one another
 {
     "player_number": Int (1 | 2),
     "board": String[8][8],
-    "player_move": [4]
+    "player_move": [4],
+    "pawn_promotion": String
 }
 ```
 
@@ -119,7 +120,10 @@ Or if game could not be started because server is full:
 `submitBoard`:
 
 ```
-{ "status_code": 200 }
+{
+    "status_code": 200,
+    "board_data": String[8][8]
+}
 ```
 
 <hr>

--- a/board.py
+++ b/board.py
@@ -346,6 +346,23 @@ class Board:
 
         return legal_moves
 
+    def pawn_promotion(self, piece_type, loc):
+        # get color
+        if not self.is_square_empty(loc[0], loc[1]) and self.board[loc[0]][loc[1]].rep == "P":
+            player_color = self.board[loc[0]][loc[1]].color
+        # promote
+        if piece_type == "knight":
+            self.board[loc[0]][loc[1]] = Knight(player_color, loc[0], loc[1])
+        elif piece_type == "bishop":
+            self.board[loc[0]][loc[1]] = Bishop(player_color, loc[0], loc[1])
+        elif piece_type == "rook":
+            self.board[loc[0]][loc[1]] = Rook(player_color, loc[0], loc[1])
+            self.board[loc[0]][loc[1]].can_castle = False
+        elif piece_type == "Queen":
+            self.board[loc[0]][loc[1]] = Queen(player_color, loc[0], loc[1])
+        else:
+            return
+
     def apply_move(self, player_color, move):
         """
         Get move, apply move to board,
@@ -399,39 +416,6 @@ class Board:
                     self.board[0][0].can_castle = False
                     self.move_piece_fast(0, 4, 0, 2)
                     self.move_piece_fast(0, 0, 0, 3)
-        elif sum(move) >= 40:  # short hand for types of promotions
-            if not self.is_square_empty(1, move[1]) and\
-                    self.board[1][move[1]].rep == "P" and \
-                    self.board[1][move[1]].color == "white":
-                if move[2:] == [20, 20]:
-                    self.board[0][move[1]] = Knight(player_color, 0, move[1])
-                    self.board[1][move[1]] = "noPiece"
-                elif move[2:] == [30, 30]:
-                    self.board[0][move[1]] = Bishop(player_color, 0, move[1])
-                    self.board[1][move[1]] = "noPiece"
-                elif move[2:] == [40, 40]:
-                    self.board[0][move[1]] = Rook(player_color, 0, move[1])
-                    self.board[0][move[1]].can_castle = False
-                    self.board[1][move[1]] = "noPiece"
-                else:
-                    self.board[0][move[1]] = Queen(player_color, 0, move[1])
-                    self.board[1][move[1]] = "noPiece"
-            elif not self.is_square_empty(6, move[1]) and\
-                    self.board[7][move[1]].rep == "P" and \
-                    self.board[1][move[1]].color == "black":
-                if move[2:] == [20, 20]:
-                    self.board[7][move[1]] = Knight(player_color, 7, move[1])
-                    self.board[6][move[1]] = "noPiece"
-                elif move[2:] == [30, 30]:
-                    self.board[7][move[1]] = Bishop(player_color, 7, move[1])
-                    self.board[6][move[1]] = "noPiece"
-                elif move[2:] == [40, 40]:
-                    self.board[7][move[1]] = Rook(player_color, 7, move[1])
-                    self.board[7][move[1]].can_castle = False
-                    self.board[6][move[1]] = "noPiece"
-                else:
-                    self.board[7][move[1]] = Queen(player_color, 7, move[1])
-                    self.board[6][move[1]] = "noPiece"
         else:
             piece = self.board[fx][fy]
             if piece.rep == "K":

--- a/board.py
+++ b/board.py
@@ -347,6 +347,7 @@ class Board:
         return legal_moves
 
     def pawn_promotion(self, piece_type, loc):
+        pawn_color = ""
         # get color
         if not self.is_square_empty(loc[0], loc[1]) and self.board[loc[0]][loc[1]].rep == "P":
             pawn_color = self.board[loc[0]][loc[1]].color

--- a/board.py
+++ b/board.py
@@ -349,17 +349,19 @@ class Board:
     def pawn_promotion(self, piece_type, loc):
         # get color
         if not self.is_square_empty(loc[0], loc[1]) and self.board[loc[0]][loc[1]].rep == "P":
-            player_color = self.board[loc[0]][loc[1]].color
+            pawn_color = self.board[loc[0]][loc[1]].color
+        else:
+            return
         # promote
         if piece_type == "knight":
-            self.board[loc[0]][loc[1]] = Knight(player_color, loc[0], loc[1])
+            self.board[loc[0]][loc[1]] = Knight(pawn_color, loc[0], loc[1])
         elif piece_type == "bishop":
-            self.board[loc[0]][loc[1]] = Bishop(player_color, loc[0], loc[1])
+            self.board[loc[0]][loc[1]] = Bishop(pawn_color, loc[0], loc[1])
         elif piece_type == "rook":
-            self.board[loc[0]][loc[1]] = Rook(player_color, loc[0], loc[1])
+            self.board[loc[0]][loc[1]] = Rook(pawn_color, loc[0], loc[1])
             self.board[loc[0]][loc[1]].can_castle = False
         elif piece_type == "Queen":
-            self.board[loc[0]][loc[1]] = Queen(player_color, loc[0], loc[1])
+            self.board[loc[0]][loc[1]] = Queen(pawn_color, loc[0], loc[1])
         else:
             return
 

--- a/server.py
+++ b/server.py
@@ -203,7 +203,12 @@ def submit_board():
     arguments = request.get_json()
     player_number = arguments["player_number"]
     player_move = arguments["player_move"]
+    pawn_promotion_piece = arguments["pawn_promotion"]
+    
+    # Applying player move
     board.apply_move(players[player_number].color, player_move)
+    if not (pawn_promotion_piece == ""):
+        board.pawn_promotion(pawn_promotion_piece, player_move[2:])
 
     # Switching players
     players[player_number].is_turn = False


### PR DESCRIPTION
There a few cases where pawn promotion does not work as it should such as not working for black pawns, and not working when a pawn takes a space in row 8 that is already occupied. This PR is meant to fix those bugs.

This addresses #51 